### PR TITLE
Add admin dashboard home with stats overview (#20)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "Next.js Dev",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -1,31 +1,80 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { signOut } from "next-auth/react";
+
+const navItems = [
+  { label: "Dashboard", href: "/admin" },
+  { label: "Events", href: "/admin/events" },
+  { label: "Signups", href: "/admin/signups" },
+  { label: "Officers", href: "/admin/officers" },
+  { label: "Lineages", href: "/admin/lineages" },
+  { label: "Announcements", href: "/admin/announcements" },
+  { label: "Messages", href: "/admin/messages" },
+];
 
 export default function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const router = useRouter();
+
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col bg-gray-50">
       <nav className="bg-primary-dark text-white">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
           <Link href="/admin" className="text-xl font-bold tracking-tight">
-            ACM@JHU <span className="text-sm font-normal opacity-70">Admin</span>
+            ACM@JHU{" "}
+            <span className="text-sm font-normal opacity-70">Admin</span>
           </Link>
 
-          <button
-            onClick={() => signOut({ callbackUrl: "/login" })}
-            className="rounded-md border border-white/30 px-3 py-1.5 text-sm font-medium transition-colors hover:bg-white/10"
-          >
-            Log out
-          </button>
+          <div className="flex items-center gap-4">
+            <Link
+              href="/"
+              className="text-sm text-gray-300 transition-colors hover:text-white"
+            >
+              View site
+            </Link>
+            <button
+              onClick={() => signOut({ callbackUrl: "/login" })}
+              className="rounded-md border border-white/30 px-3 py-1.5 text-sm font-medium transition-colors hover:bg-white/10"
+            >
+              Log out
+            </button>
+          </div>
         </div>
       </nav>
 
-      <main className="flex-1 bg-gray-50">
-        <div className="mx-auto max-w-6xl px-6 py-8">{children}</div>
-      </main>
+      <div className="mx-auto flex w-full max-w-6xl flex-1 px-6 py-6">
+        {/* Sidebar */}
+        <aside className="mr-8 w-48 shrink-0">
+          <nav className="space-y-1">
+            {navItems.map((item) => {
+              const isActive =
+                item.href === "/admin"
+                  ? router.pathname === "/admin"
+                  : router.pathname.startsWith(item.href);
+
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`block rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                    isActive
+                      ? "bg-primary-light text-primary"
+                      : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                  }`}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </aside>
+
+        {/* Main content */}
+        <main className="min-w-0 flex-1">{children}</main>
+      </div>
     </div>
   );
 }

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,6 +1,97 @@
 import Head from "next/head";
+import Link from "next/link";
+import type { GetServerSideProps } from "next";
+import { prisma } from "@/lib/prisma";
 
-export default function AdminDashboard() {
+interface RecentSignup {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: string;
+  eventName: string;
+}
+
+interface Props {
+  totalUniqueSignups: number;
+  upcomingEventsCount: number;
+  recentSignups: RecentSignup[];
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async () => {
+  const now = new Date();
+
+  const [uniqueSignups, upcomingEventsCount, recentSignups] = await Promise.all(
+    [
+      prisma.eventSignup
+        .findMany({
+          select: { email: true },
+          distinct: ["email"],
+        })
+        .then((rows) => rows.length),
+
+      prisma.event.count({
+        where: { endTime: { gte: now } },
+      }),
+
+      prisma.eventSignup.findMany({
+        orderBy: { createdAt: "desc" },
+        take: 10,
+        include: { event: { select: { name: true } } },
+      }),
+    ],
+  );
+
+  return {
+    props: {
+      totalUniqueSignups: uniqueSignups,
+      upcomingEventsCount,
+      recentSignups: recentSignups.map((s) => ({
+        id: s.id,
+        name: s.name,
+        email: s.email,
+        createdAt: s.createdAt.toISOString(),
+        eventName: s.event.name,
+      })),
+    },
+  };
+};
+
+function StatCard({
+  label,
+  value,
+  href,
+}: {
+  label: string;
+  value: number;
+  href: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+    >
+      <p className="text-sm font-medium text-gray-500">{label}</p>
+      <p className="mt-1 text-3xl font-bold text-primary-dark">{value}</p>
+    </Link>
+  );
+}
+
+function formatRelativeTime(iso: string) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export default function AdminDashboard({
+  totalUniqueSignups,
+  upcomingEventsCount,
+  recentSignups,
+}: Props) {
   return (
     <>
       <Head>
@@ -8,9 +99,92 @@ export default function AdminDashboard() {
       </Head>
 
       <h1 className="text-2xl font-bold text-primary-dark">Dashboard</h1>
-      <p className="mt-2 text-gray-600">
-        Welcome to the ACM@JHU admin dashboard.
+      <p className="mt-1 text-gray-600">
+        Overview of ACM@JHU activity.
       </p>
+
+      {/* Stats */}
+      <div className="mt-6 grid gap-4 sm:grid-cols-2">
+        <StatCard
+          label="Unique signups"
+          value={totalUniqueSignups}
+          href="/admin/signups"
+        />
+        <StatCard
+          label="Upcoming events"
+          value={upcomingEventsCount}
+          href="/admin/events"
+        />
+      </div>
+
+      {/* Recent signups */}
+      <section className="mt-8">
+        <h2 className="text-lg font-semibold text-gray-900">Recent signups</h2>
+
+        {recentSignups.length === 0 ? (
+          <p className="mt-3 text-sm text-gray-500">No signups yet.</p>
+        ) : (
+          <div className="mt-3 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-gray-200 bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 font-medium text-gray-600">
+                    Name
+                  </th>
+                  <th className="px-4 py-2.5 font-medium text-gray-600">
+                    Email
+                  </th>
+                  <th className="px-4 py-2.5 font-medium text-gray-600">
+                    Event
+                  </th>
+                  <th className="px-4 py-2.5 font-medium text-gray-600">
+                    When
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {recentSignups.map((s) => (
+                  <tr key={s.id}>
+                    <td className="px-4 py-2.5 font-medium text-gray-900">
+                      {s.name}
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-500">{s.email}</td>
+                    <td className="px-4 py-2.5 text-gray-700">
+                      {s.eventName}
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-400">
+                      {formatRelativeTime(s.createdAt)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Quick links */}
+      <section className="mt-8">
+        <h2 className="text-lg font-semibold text-gray-900">Quick links</h2>
+        <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {[
+            { label: "Manage Events", href: "/admin/events" },
+            { label: "View Signups", href: "/admin/signups" },
+            { label: "Manage Officers", href: "/admin/officers" },
+            { label: "Manage Lineages", href: "/admin/lineages" },
+            { label: "Announcements", href: "/admin/announcements" },
+            { label: "Contact Messages", href: "/admin/messages" },
+          ].map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-primary-mid transition-colors hover:bg-primary-light"
+            >
+              {link.label} &rarr;
+            </Link>
+          ))}
+        </div>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Adds sidebar navigation to `AdminLayout` with links to all admin sub-sections and active route highlighting
- Implements `pages/admin/index.tsx` dashboard home with total unique signups, upcoming events count, recent signups table (last 10), and quick navigation links
- Adds `bg-gray-50` background and "View site" link to admin layout

Closes #20

## Test plan
- [x] Navigate to `/admin` and verify stats cards show correct counts
- [x] Verify recent signups table displays name, email, event, and relative time
- [x] Verify sidebar nav links highlight the active route
- [x] Verify quick links navigate to the correct admin sub-sections
- [x] Verify "View site" returns to the public site and "Log out" signs out

🤖 Generated with [Claude Code](https://claude.com/claude-code)